### PR TITLE
Relax torch version requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Changes from previous releases are listed below.
 
 ## Upcoming Release
 
-*No changes yet.*
+<!-- *No changes yet.* -->
+- Relax the torch version requirement to `torch>=2.0` instead of `torch==2.2.0` _(see #1 and #2)_
 
 ## 0.1.0 (2024-04-26)
 

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -1,2 +1,4 @@
+# Updating the torch version might require changes to the Cuda Version in the Makefile as well
+torch==2.2.0
 tox
 tox-ignore-env-name-mismatch

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,7 +9,6 @@ pyogrio
 rasterio
 requests
 scikit-learn
-# Updating the torch version might require changes to the Cuda Version in the Makefile as well
-torch==2.2.0
+torch>=2.0
 typer[all]
 types-requests


### PR DESCRIPTION
Closes #1 

**Applies the suggested change:** Relax the requirement.in dependency to torch>=2.0 and only pin the version to torch==2.2.0 matching the makefile Cuda version in the requirements-dev.in.